### PR TITLE
Add a connection string for bucardo wrapper.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -24,6 +24,11 @@ databases:
         host: <host>
         port: 5432
 
+        # This is a separate setting because there are two relevant sets of
+        # permissions, and in RDS there may not be a single user that has all
+        # necessary privileges.
+        schema_owner: <schema_owner>
+
         # Set cascade to true if both of these are true:
         # - You are setting up a replication topology of A -> B -> C,
         #   where changes propagate from A to B and from B to C.

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -45,6 +45,7 @@ class Plugin():
         cfg: contents of the config file as a dictionary
         primary: config data for primary database connection
         primary_conn_pg_format: primary db connection string
+        primary_schema_owner_conn_pg_format: primary db connection string
         secondary: config data for secondary database connection
         secondary_db_owner_conn_pg_format: secondary db connection string
         secondary_schema_owner_conn_pg_format: secondary db connection string
@@ -80,6 +81,12 @@ class Plugin():
             user=self.bucardo['database_owner'],
         )
         self.primary_conn_pg_format = self._connect(self.primary, user=self.primary['database_owner'])
+        # This is a psycopg2 conn string for the primary database, used when we need to
+        # perform DDL on replicated tables, there isn't a superuser because it's RDS,
+        # and the "superuser" doesn't have the necessary permissions on the relevant
+        # tables.
+        self.primary_schema_owner_conn_pg_format = \
+            self._connect(self.primary, user=self.primary['schema_owner'])
         # This is a psycogp2 conn string for the secondary database, used when we need
         # "superuser" privs on an RDS database.
         self.secondary_db_owner_conn_pg_format = self._connect(self.secondary, user=self.secondary['database_owner'])

--- a/plugins/bucardo/__init__.py
+++ b/plugins/bucardo/__init__.py
@@ -256,7 +256,7 @@ class Bucardo(Plugin):
 
         # Bucardo puts three triggers on each table, with predictable names.
         triggers = ['bucardo_delta', f'bucardo_kick_{self.repl_name}', f'bucardo_note_trunc_{self.repl_name}']
-        conn = psycopg2.connect(self.primary_conn_pg_format)
+        conn = psycopg2.connect(self.primary_schema_owner_conn_pg_format)
         # Drop each trigger from each table.
         for table in tables:
             for trigger in triggers:


### PR DESCRIPTION
A separate schema owner setting for the primary database is necessary for
dropping triggers in the case that the table owner is different from the
database owner and it's an RDS database, meaning there's no superuser.