### PR TITLE
Asynchronous bucardo kicking.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -35,6 +35,10 @@ databases:
         # - The current config is for managing the B -> C replication.
         cascade: False
 
+        # Set disable_kicking to true if you want the secondary to be notified
+        # about new data every second, instead of every time a commit comes in.
+        disable_kicking: True
+
     secondary:
         database_owner: <db2_owner>
         dbname: <db2_name>


### PR DESCRIPTION
Instead of kicking the bucardo sync synchronously using a trigger, give the
user an option to disable the trigger and instead run a process every second in
the background to do the kicking.