### PR TITLE
INF-6236: Incorporate async kicking changes into the retry plugin.

### DIFF
--- a/plugins/retry/__init__.py
+++ b/plugins/retry/__init__.py
@@ -120,17 +120,18 @@ class Retry(Plugin):
                         print(notice, end='')
             finally:
                 conn.close()
+            if self.cfg['databases']['primary'].get('cascade'):
+                self.bucardo_instance._toggle_kick_triggers('enable always')
+            if self.cfg['databases']['primary'].get('disable_kicking'):
+                self.bucardo_instance._toggle_kick_triggers('disable')
         else:
             self.bucardo_instance.add_triggers()
-
-        if self.cfg['databases']['primary'].get('cascade'):
-            self.bucardo_instance._enable_cascade_triggers()
 
         self._set_timeout(self.primary_user, 'DEFAULT')
 
         print(
             'Attempted to add triggers. Check the output above for warnings about missing triggers. '
-            'If you see any, just run try_add again. If there are no warnings, you should be good to go.'
+            'If you see any, just run add_triggers again. If there are no warnings, you should be good to go.'
         )
 
     def drop_triggers(self):


### PR DESCRIPTION
A recent commit added new functionality to the bucardo plugin, relating to
sync-kicking behavior. It also changed the name of a function. Since the retry
plugin inherits from the bucardo plugin and reuses some of its logic, the
corresponding changes need to be applied to the retry plugin.

There was also a bit of verbiage that dates to a very old version of this code
that needed updating.