### PR TITLE
Fix trigger bugs in bucardo.

### DIFF
--- a/docs/bucardo.md
+++ b/docs/bucardo.md
@@ -278,7 +278,7 @@ type: "AccessExclusiveLock on object 0 of class 1262 of database 0". There is,
 as far as I can tell, only one such object. So too much concurrent activity all
 trying to get that same lock can cause a bottleneck.
 
-To avoid that, you can set `disable_kicking` in the `bucardo:primary` section
+To avoid that, you can set `asynchronous_kicking` in the `bucardo` section
 of the config. What that will do is disable the kick trigger during the
 `add_triggers` action, and spawn a background process during `start` and
 `restart` to do the kicking instead. Kicking will be done once per second,
@@ -287,11 +287,8 @@ throughout the day, or if you don't mind bucardo checking for changes and not
 always finding them. (There is a small performance overhead to any needless
 activity.)
 
-The pid will be printed when `start` or `restart` is run. This pid isn't stored
-by the script and isn't managed by it. A new process is spawned each time you
-run `restart`. It's up to you to kill it.
-
-TODO: Write the pid to a pidfile and manage the process.
+The process that does the asynchronous kicking will be killed and restarted as
+needed by the `bucardo.start`, `bucardo.stop`, and `bucardo.restart` commands.
 
 # Logs and pidfiles
 

--- a/plugins/retry/__init__.py
+++ b/plugins/retry/__init__.py
@@ -120,10 +120,10 @@ class Retry(Plugin):
                         print(notice, end='')
             finally:
                 conn.close()
-            if self.cfg['databases']['primary'].get('cascade'):
-                self.bucardo_instance._toggle_kick_triggers('enable always')
-            if self.cfg['databases']['primary'].get('disable_kicking'):
-                self.bucardo_instance._toggle_kick_triggers('disable')
+
+            # Enable and disable triggers as needed.
+            self.bucardo_instance._manage_triggers()
+
         else:
             self.bucardo_instance.add_triggers()
 


### PR DESCRIPTION
Bug 1: In a cascading replication toplogy, truncates on the first database
were not being propagated down to the third database. Setting the trunc trigger
on the second database to always be enabled fixes this.

Bug 2: Enabling and disabling of triggers wasn't idempotent and was
furthermore somewhat arbitrary if you had a certain combination of settings.
This change makes the trigger logic consistent with the intent of the settings.

Bug 3: A function was called by an old name that got missed in a previous refactor.

Bug 4: The documentation referred to the old state in a couple places.

Also updated some double quotes to single quotes for consistency.