### PR TITLE
Recover gracefully after a server restart.

### DIFF
--- a/plugins/bucardo/__init__.py
+++ b/plugins/bucardo/__init__.py
@@ -456,6 +456,8 @@ EOF"""
     def start(self):
         """Start bucardo daemon."""
         print("Starting daemon.")
+        # The piddir gets deleted after the bucardo server is restarted, and bucardo won't start without it.
+        os.system(f"mkdir -p {self.piddir}")
         os.system(f"bucardo {self.bucardo_opts} {self.bucardo_conn_bucardo_format} start")
         if self.cfg["bucardo"].get("asynchronous_kicking"):
             self._async_kick_start()


### PR DESCRIPTION
Recreate the piddir automatically so bucardo won't refuse to restart if it's missing. Will do nothing if the piddir is already there.